### PR TITLE
RequestBody 응답 데이터 한글 깨짐 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,7 +22,6 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     sourceCompatibility = '11'
-    compileJava.options.encoding = 'UTF-8'
 
     repositories {
         mavenCentral()

--- a/backend/jikji-common/src/main/java/com/readers/jikji/Hello.java
+++ b/backend/jikji-common/src/main/java/com/readers/jikji/Hello.java
@@ -4,5 +4,5 @@ import lombok.Data;
 
 @Data
 public class Hello {
-    private String hello = "hello";
+    private String hello = "안녕";
 }

--- a/backend/jikji-core/build.gradle
+++ b/backend/jikji-core/build.gradle
@@ -2,6 +2,3 @@ bootJar {
     enabled = false
 }
 
-dependencies {
-
-}

--- a/backend/jikji-core/src/docs/init-DDL.sql
+++ b/backend/jikji-core/src/docs/init-DDL.sql
@@ -1,0 +1,6 @@
+-- -----------------------------------------------------
+-- Schema jikji
+-- -----------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS `jikji` DEFAULT CHARACTER SET utf8 ;
+USE `jikji` ;
+

--- a/backend/jikji-server/src/main/java/com/readers/jikji/config/WebConfig.java
+++ b/backend/jikji-server/src/main/java/com/readers/jikji/config/WebConfig.java
@@ -1,9 +1,6 @@
 package com.readers.jikji.config;
 
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/backend/jikji-server/src/main/java/com/readers/jikji/web/HelloController.java
+++ b/backend/jikji-server/src/main/java/com/readers/jikji/web/HelloController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HelloController {
 
-    @GetMapping("/hello")
+    @GetMapping(value="/hello", produces="text/plain;charset=UTF-8")
     public String hello(){
         Hello hello = new Hello();
         System.out.println(hello.getHello());

--- a/backend/jikji-server/src/main/resources/application.properties
+++ b/backend/jikji-server/src/main/resources/application.properties
@@ -1,2 +1,10 @@
-# Server
+# \uC11C\uBC84 \uD3EC\uD2B8
 server.port = 7000
+
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true
+server.servlet.encoding.force-response=true
+
+spring.messages.basename=messages
+spring.messages.encoding=UTF-8

--- a/backend/jikji-server/src/test/java/com/readers/jikji/web/HelloControllerTest.java
+++ b/backend/jikji-server/src/test/java/com/readers/jikji/web/HelloControllerTest.java
@@ -17,7 +17,7 @@ public class HelloControllerTest {
 
     @Test
     public void hello가_리턴된다() throws Exception {
-        String hello = "hello";
+        String hello = "안녕";
 
         mvc.perform(get("/hello")) //MockMvc를 통해 /hello 주소로 HTTP GET 요청
                 .andExpect(status().isOk()) //상태 검증

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,6 +1,5 @@
 rootProject.name = 'project-jikji'
 include 'jikji-core'
 include 'jikji-common'
-include 'jikji-core'
 include 'jikji-server'
 


### PR DESCRIPTION
## ❓ Description

- ResponseBody로 응답 데이터를 반환할 때 한글이 깨져서 인코딩 관련 문제를 해결함

## 🖍️ Changes details

- 버전 상의 문제인지 JavaConfig 전역으로 필터를 통해 설정하려고 했는데 자꾸 깨져서 RequestMapping의 produces 속성으로 해결함
